### PR TITLE
seperate model graph creation from training script into a class

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -1,0 +1,110 @@
+import tensorflow as tf
+import encoders
+import decoders
+from loss import reconstruction_loss
+
+
+def z_sample(mu_z, log_sigma):
+    sampled = tf.random_normal(shape=tf.shape(mu_z))
+    return mu_z + sampled * tf.exp(log_sigma / 2)
+
+
+class Model(object):
+    def __init__(self, args):
+        # AttributeErrors not handled
+        # fail early if the encoder and decoder are not found
+        self.encoder = getattr(encoders, args.encoder)
+        self.decoder = getattr(decoders, args.decoder)
+
+        # graph definition
+        with tf.Graph().as_default() as g:
+            # placeholders
+            # target frame, number of channels is always one for GIF
+            self.T = tf.placeholder(tf.float32, shape=(
+                args.batch_size,
+                args.crop_height,
+                args.crop_width,
+                1)
+            )
+
+            self.Z_in = tf.placeholder(tf.float32, shape=(
+                args.batch_size,
+                args.z_dim)
+            )
+
+            # input frame(s), this depends on network parameters
+            if args.crop_pos is not None:
+                # non FCN case
+                if args.window_size > 1:
+                    self.X = tf.placeholder(tf.float32, shape=(
+                        args.batch_size,
+                        args.window_size,
+                        args.crop_height,
+                        args.crop_width,
+                        1)
+                    )
+                else:
+                    self.X = tf.placeholder(tf.float32, shape=(
+                        args.batch_size,
+                        args.crop_height,
+                        args.crop_width,
+                        1)
+                    )
+            else:
+                # FCN case
+                if args.window_size > 1:
+                    self.X = tf.placeholder(
+                        tf.float32,
+                        shape=(1, args.window_size, None, None, 1)
+                    )
+                else:
+                    self.X = tf.placeholder(
+                        tf.float32,
+                        shape=(1, None, None, 1)
+                    )
+                # TODO: remove this once FCN networks have been added
+                raise NotImplementedError
+
+            # feed into networks, with their own unique name_scopes
+            if args.encoder == "vae_encoder":
+                mu, sigma = self.encoder(self.X, args)
+                self.Z = z_sample(mu, sigma)
+            else:
+                mu, sigma = None, None
+                self.Z = self.encoder(self.X, args)
+
+            self.T_hat = self.decoder(self.Z, args, reuse=tf.AUTO_REUSE)
+            self.decompression_op = self.decoder(
+                self.Z_in, args, reuse=tf.AUTO_REUSE)
+
+            # calculate loss
+            with tf.name_scope("loss"):
+                mu = mu if mu is not None else None
+                sigma = sigma if sigma is not None else None
+                self.loss_op = reconstruction_loss(
+                    self.T_hat,
+                    self.T,
+                    args.loss,
+                    mu, sigma,
+                    args.l1_reg_strength,
+                    args.l2_reg_strength
+                )
+
+            # optimizer
+            with tf.name_scope("optim"):
+                self.optimizer = tf.train.AdamOptimizer(
+                    learning_rate=args.learning_rate)
+                # grads = optimizer.compute_gradients(loss_op)
+                self.train_op = self.optimizer.minimize(self.loss_op)
+
+            # summaries
+            with tf.name_scope("summary"):
+                tf.summary.scalar("sumary_loss", self.loss_op)
+                tf.summary.image("sumary_target", self.T)
+                tf.summary.image("sumary_recon", self.T_hat)
+                self.summary_op = tf.summary.merge_all()
+
+            with tf.name_scope("init"):
+                self.init_op = tf.global_variables_initializer()
+
+            self.graph = g

--- a/src/train.py
+++ b/src/train.py
@@ -1,24 +1,14 @@
 import os
 import tensorflow as tf
-
-import encoders
-import decoders
-import transforms
 from arg_parser import parse_train_args
 from dataset_util import Dataset
-from loss import reconstruction_loss
-
-
-def z_sample(mu_z, log_sigma):
-    sampled = tf.random_normal(shape=tf.shape(mu_z))
-    return mu_z + sampled*tf.exp(log_sigma/2)
+from model import Model
+import transforms
 
 
 def train(args):
-    # AttributeErrors not handled
-    # fail early if the encoder and decoder are not found
-    encoder = getattr(encoders, args.encoder)
-    decoder = getattr(decoders, args.decoder)
+    model = Model(args)
+
     input_transform = None
     if args.input_transform is not None:
         input_transform = getattr(transforms, args.input_transform)
@@ -37,98 +27,16 @@ def train(args):
     if not os.path.exists(args.save_path):
         os.makedirs(args.save_path)
 
-    # graph definition
-    with tf.Graph().as_default() as g:
-        # placeholders
-        # target frame, number of channels is always one for GIF
-        T = tf.placeholder(tf.float32, shape=(
-            args.batch_size,
-            args.crop_height,
-            args.crop_width,
-            1)
-        )
-        # input frame(s), this depends on network parameters
-        if args.crop_pos is not None:
-            # non FCN case
-            if args.window_size > 1:
-                X = tf.placeholder(tf.float32, shape=(
-                    args.batch_size,
-                    args.window_size,
-                    args.crop_height,
-                    args.crop_width,
-                    1)
-                )
-            else:
-                X = tf.placeholder(tf.float32, shape=(
-                    args.batch_size,
-                    args.crop_height,
-                    args.crop_width,
-                    1)
-                )
-        else:
-            # FCN case
-            if args.window_size > 1:
-                X = tf.placeholder(
-                    tf.float32,
-                    shape=(1, args.window_size, None, None, 1)
-                )
-            else:
-                X = tf.placeholder(
-                    tf.float32,
-                    shape=(1, None, None, 1)
-                )
-            # TODO: remove this once FCN networks have been added
-            raise NotImplementedError
-
-        # feed into networks, with their own unique name_scopes
-        if args.encoder == "vae_encoder":
-            mu, sigma = encoder(X, args)
-            Z = z_sample(mu, sigma)
-        else:
-            mu, sigma = None, None
-            Z = encoder(X, args)
-
-        T_hat = decoder(Z, args)
-
-        # calculate loss
-        with tf.name_scope("loss"):
-            mu = mu if mu is not None else None
-            sigma = sigma if sigma is not None else None
-            loss_op = reconstruction_loss(
-                T_hat, T,
-                args.loss,
-                mu, sigma,
-                args.l1_reg_strength,
-                args.l2_reg_strength
-            )
-
-        # optimizer
-        with tf.name_scope("optim"):
-            optimizer = tf.train.AdamOptimizer(
-                learning_rate=args.learning_rate)
-            # grads = optimizer.compute_gradients(loss_op)
-            train_op = optimizer.minimize(loss_op)
-
-        # summaries
-        with tf.name_scope("summary"):
-            tf.summary.scalar("sumary_loss", loss_op)
-            tf.summary.image("sumary_target", T)
-            tf.summary.image("sumary_recon", T_hat)
-            summary_op = tf.summary.merge_all()
-
-        with tf.name_scope("init"):
-            init_op = tf.global_variables_initializer()
-
     # graph execution
     print('starting training with learning rate = {}'
-        .format(args.learning_rate))
-    with tf.Session(graph=g) as sess:
+          .format(args.learning_rate))
+    with tf.Session(graph=model.graph) as sess:
         summary_writer = tf.summary.FileWriter(
             os.path.join(args.save_path, "log"), sess.graph)
         saver = tf.train.Saver()
 
         # init graph variables
-        sess.run(init_op)
+        sess.run(model.init_op)
 
         # attempt to resume previous training
         epoch = 0
@@ -142,7 +50,7 @@ def train(args):
             print("Restored global epoch {}".format(epoch))
         else:
             print("Strating new model training for save path {}"
-                .format(args.save_path))
+                  .format(args.save_path))
 
         # Main training loop
         try:
@@ -153,17 +61,17 @@ def train(args):
                         dataset.generate_training_batch():
 
                     loss, _, summary = sess.run(
-                        [loss_op, train_op, summary_op],
+                        [model.loss_op, model.train_op, model.summary_op],
                         feed_dict={
-                            X: input_frames,
-                            T: target_frames
+                            model.X: input_frames,
+                            model.T: target_frames
                         }
                     )
 
                     itr += 1
                     if itr % args.log_interval == 0:
                         print("Epoch {} Itr {} loss = {}"
-                            .format(epoch, itr, loss))
+                              .format(epoch, itr, loss))
 
                         # update summaries. update global step
                         summary_writer.add_summary(


### PR DESCRIPTION
this commit begins to address the challenges that we are facing with GH-12

by separating the model from the training script we can use the same graph creation utils in the inference scripts fro compression and decompression. This commit also adds a second decoder net which reuses the params of the first. this one accepts a 'Z_in' placeholder instead of directly taking in the encoder output. This is what we will use for decompression, so this at least should allow us to start implementing compress.py and decompress.py

The outstanding issue still is that the graph contains both the encoder and decoder. I am not sure how to selectively load only one of them during inference, but this is at least a step in the right direction.